### PR TITLE
Batch label untransformed bug

### DIFF
--- a/cytonormpy/__init__.py
+++ b/cytonormpy/__init__.py
@@ -53,3 +53,5 @@ __all__ = [
     "emd_from_anndata",
     "emd_comparison_from_anndata"
 ]
+
+__version__ = '0.0.3'

--- a/cytonormpy/_utils/_utils.py
+++ b/cytonormpy/_utils/_utils.py
@@ -49,6 +49,8 @@ def _select_interpolants_numba(x: np.ndarray,
                 tauS = 3 * Sk / np.sqrt(alpha**2 + beta**2)
                 m[k] = tauS * alpha
                 m[k1] = tauS * beta
+    assert m.shape[0] == x.shape[0]
+    assert m.shape[0] == y.shape[0]
     return m
 
 @njit(float64(float64[:]))
@@ -221,8 +223,8 @@ def _regularize(x: np.ndarray,
         x = x[idxs]
         y = y[idxs]
 
-        assert x.shape[0] == y.shape[0]
-
+    
+    assert x.shape[0] == y.shape[0]
     return x, y
 
 @njit(Tuple((float64[:], float64[:]))(float64[:], float64[:]))

--- a/cytonormpy/tests/test_data_precision.py
+++ b/cytonormpy/tests/test_data_precision.py
@@ -49,6 +49,41 @@ def test_without_clustering_fcs(metadata: pd.DataFrame,
             python_version.original_events,
         )
 
+def test_without_clustering_fcs_string_batch(metadata: pd.DataFrame,
+                                             INPUT_DIR: Path,
+                                             tmpdir: Path):
+    metadata = metadata.copy()
+    metadata["batch"] = [f"batch_{entry}" for entry in metadata["batch"].tolist()]
+    cn = cnp.CytoNorm()
+    t = AsinhTransformer()
+    cn.add_transformer(t)
+    detectors = pd.read_csv(os.path.join(INPUT_DIR, "coding_detectors.txt"), header = None)[0].tolist()
+    cn.run_fcs_data_setup(metadata = metadata,
+                          input_directory = INPUT_DIR,
+                          output_directory = tmpdir,
+                          channels = detectors)
+
+    cn.calculate_quantiles(n_quantiles = 99)
+    cn.calculate_splines()
+    cn.normalize_data()
+
+    normalized_files = [
+        "Norm_Gates_PTLG021_Unstim_Control_2.fcs",
+        "Norm_Gates_PTLG028_Unstim_Control_2.fcs",
+        "Norm_Gates_PTLG034_Unstim_Control_2.fcs",
+    ]
+
+    for file in normalized_files:
+        r_version = FCSFile(INPUT_DIR, file)
+        python_version = FCSFile(Path(tmpdir), file)
+
+        assert r_version.channels.index.tolist() == python_version.channels.index.tolist()
+
+        assert np.array_equal(
+            r_version.original_events,
+            python_version.original_events,
+        )
+
 
 def _create_anndata(input_dir, file_list):
     adatas = []
@@ -101,6 +136,46 @@ def test_without_clustering_anndata(data_anndata: AnnData,
     r_anndata = _create_anndata(INPUT_DIR, r_normalized_files)
 
     data_anndata.obs["batch"] = data_anndata.obs["batch"].astype(np.int8)
+    data_anndata.obs["batch"] = data_anndata.obs["batch"].astype("category")
+
+
+    cn = cnp.CytoNorm()
+    t = AsinhTransformer()
+    cn.add_transformer(t)
+    detectors = pd.read_csv(os.path.join(INPUT_DIR, "coding_detectors.txt"), header = None)[0].tolist()
+    cn.run_anndata_setup(adata = data_anndata,
+                         layer = "compensated",
+                         channels = detectors,
+                         key_added = "normalized")
+    cn.calculate_quantiles(n_quantiles = 99)
+    cn.calculate_splines()
+    cn.normalize_data()
+
+    assert "normalized" in data_anndata.layers.keys()
+
+    comp_data = data_anndata[data_anndata.obs["reference"] == "other",:].copy()
+
+    assert comp_data.obs["file_name"].unique().tolist() == r_anndata.obs["file_name"].unique().tolist()
+    assert comp_data.obs["file_name"].tolist() == r_anndata.obs["file_name"].tolist()
+    assert comp_data.shape == r_anndata.shape
+
+    np.testing.assert_array_almost_equal(
+        np.array(r_anndata.layers["normalized"]),
+        np.array(comp_data.layers["normalized"]),
+        decimal = 3
+    )
+
+def test_without_clustering_anndata_string_batch(data_anndata: AnnData,
+                                                 INPUT_DIR: Path):
+    r_normalized_files = [
+        "Norm_Gates_PTLG021_Unstim_Control_2.fcs",
+        "Norm_Gates_PTLG028_Unstim_Control_2.fcs",
+        "Norm_Gates_PTLG034_Unstim_Control_2.fcs",
+    ]
+
+    r_anndata = _create_anndata(INPUT_DIR, r_normalized_files)
+
+    data_anndata.obs["batch"] = [f"batch_{entry}" for entry in data_anndata.obs["batch"].tolist()]
     data_anndata.obs["batch"] = data_anndata.obs["batch"].astype("category")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cytonormpy"
-version = "0.0.1"
+version = "0.0.3"
 authors = [
   { name="Tarik Exner", email="Tarik.Exner@med.uni-heidelberg.de" },
 ]


### PR DESCRIPTION
As described in the commit messages:

There was an error when the quantiles were all the same values which led to a shape mismatch in the input arrays and the corresponding tangents when calculating the spline functions. There is now an if-else check for the number of unique values. If there is only one value, the identity spline is used.

There was also an error when non-numeric batch labels were used. This is now fixed. If there are non-convertible string indices, a mapping is created that maps the strings to integers. 